### PR TITLE
Refine configuration handling and database utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,25 @@ docker-compose up --build
 
 Before running the application, ensure you update the `.env` file with your API keys and other necessary configurations. An example `.env` file is provided for reference.
 
+- `DB_URL` (optional): overrides the default SQLite database location. Use a
+  PostgreSQL URL when deploying centrally.
+- `DATABASE_ECHO` (optional): set to `true` to enable SQLAlchemy query logging
+  for troubleshooting.
+- `AGENTOPS_ENABLED` / `AGENTOPS_API_KEY`: enable and configure AgentOps
+  telemetry.
+
+## Project structure
+
+The most relevant modules are documented in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+Consult it for an overview of how the Streamlit pages, persistence layer and
+supporting utilities fit together.
+
+## Versioning
+
+The application version is tracked in [`app/__init__.py`](app/__init__.py) and
+follows semantic versioning. Increment the number whenever a pull request
+introduces meaningful changes so downstream deployments can detect updates.
+
 ## Troubleshooting
 In case of problems:
 - Delete the `venv/miniconda` folder and reinstall `crewai-studio`.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,7 @@
+"""CrewAI Studio application package."""
+
+__all__ = ["__version__"]
+
+# Semantic version of the Studio application. Incremented with each meaningful
+# change to help downstream deployments detect updates.
+__version__ = "0.2.0"

--- a/app/app.py
+++ b/app/app.py
@@ -1,68 +1,118 @@
+"""Entry point for the Streamlit based CrewAI Studio application."""
+
+from functools import lru_cache
+from typing import Dict, Protocol
+
+from dotenv import load_dotenv
 import streamlit as st
 from streamlit import session_state as ss
-import db_utils
-from pg_agents import PageAgents
-from pg_tasks import PageTasks
-from pg_crews import PageCrews
-from pg_tools import PageTools
-from pg_crew_run import PageCrewRun
-from pg_export_crew import PageExportCrew
-from pg_results import PageResults
-from pg_knowledge import PageKnowledge
-from dotenv import load_dotenv
-from llms import load_secrets_fron_env
-import os
 
-def pages():
+import db_utils
+from core.config import load_settings
+from llms import load_secrets_fron_env
+from pg_agents import PageAgents
+from pg_crews import PageCrews
+from pg_export_crew import PageExportCrew
+from pg_crew_run import PageCrewRun
+from pg_knowledge import PageKnowledge
+from pg_results import PageResults
+from pg_tasks import PageTasks
+from pg_tools import PageTools
+
+
+class Page(Protocol):
+    """Protocol describing the expected page interface."""
+
+    def draw(self) -> None:
+        """Render the page contents."""
+
+
+@lru_cache(maxsize=1)
+def pages() -> Dict[str, Page]:
+    """Build and cache the Streamlit pages used by the application."""
+
     return {
-        'Crews': PageCrews(),
-        'Tools': PageTools(),
-        'Agents': PageAgents(),
-        'Tasks': PageTasks(),
-        'Knowledge': PageKnowledge(),  # Add this line
-        'Kickoff!': PageCrewRun(),
-        'Results': PageResults(),
-        'Import/export': PageExportCrew()
+        "Crews": PageCrews(),
+        "Tools": PageTools(),
+        "Agents": PageAgents(),
+        "Tasks": PageTasks(),
+        "Knowledge": PageKnowledge(),
+        "Kickoff!": PageCrewRun(),
+        "Results": PageResults(),
+        "Import/export": PageExportCrew(),
     }
 
-def load_data():
-    ss.agents = db_utils.load_agents()
-    ss.tasks = db_utils.load_tasks()
-    ss.crews = db_utils.load_crews()
-    ss.tools = db_utils.load_tools()
+
+def load_data() -> None:
+    """Populate the Streamlit session state with persisted entities."""
+
+    loaded = db_utils.load_all_entities()
+    ss.agents = loaded.agents
+    ss.tasks = loaded.tasks
+    ss.crews = loaded.crews
+    ss.tools = loaded.tools
     ss.enabled_tools = db_utils.load_tools_state()
-    ss.knowledge_sources = db_utils.load_knowledge_sources()
+    ss.knowledge_sources = loaded.knowledge_sources
 
 
-def draw_sidebar():
+def draw_sidebar() -> None:
+    """Render the navigation sidebar and handle page changes."""
+
     with st.sidebar:
         st.image("img/crewai_logo.png")
 
-        if 'page' not in ss:
-            ss.page = 'Crews'
-        
-        selected_page = st.radio('Page', list(pages().keys()), index=list(pages().keys()).index(ss.page),label_visibility="collapsed")
+        if "page" not in ss:
+            ss.page = "Crews"
+
+        labels = list(pages().keys())
+        selected_page = st.radio(
+            "Page",
+            labels,
+            index=labels.index(ss.page),
+            label_visibility="collapsed",
+        )
         if selected_page != ss.page:
             ss.page = selected_page
             st.rerun()
-            
-def main():
-    st.set_page_config(page_title="CrewAI Studio", page_icon="img/favicon.ico", layout="wide")
+
+
+def configure_environment() -> None:
+    """Load environment settings and initialise optional integrations."""
+
     load_dotenv()
     load_secrets_fron_env()
-    if (str(os.getenv('AGENTOPS_ENABLED')).lower() in ['true', '1']) and not ss.get('agentops_failed', False):
+    settings = load_settings()
+
+    if settings.agentops.is_enabled and not ss.get("agentops_failed", False):
         try:
             import agentops
-            agentops.init(api_key=os.getenv('AGENTOPS_API_KEY'),auto_start_session=False)    
-        except ModuleNotFoundError as e:
+
+            agentops.init(
+                api_key=settings.agentops.api_key,
+                auto_start_session=False,
+            )
+        except ModuleNotFoundError as exc:
             ss.agentops_failed = True
-            print(f"Error initializing AgentOps: {str(e)}")            
-        
+            print(f"Error initializing AgentOps: {exc}")
+
+
+def main() -> None:
+    """Application entry point invoked by Streamlit."""
+
+    st.set_page_config(
+        page_title="CrewAI Studio", page_icon="img/favicon.ico", layout="wide"
+    )
+    configure_environment()
     db_utils.initialize_db()
     load_data()
     draw_sidebar()
-    PageCrewRun.maintain_session_state() #this will persist the session state for the crew run page so crew run can be run in a separate thread
+
+    # Persist the session state for the crew run page so crew run can execute in a
+    # separate thread.
+    PageCrewRun.maintain_session_state()
+
     pages()[ss.page].draw()
-    
-if __name__ == '__main__':
+
+
+if __name__ == "__main__":
     main()

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,0 +1,10 @@
+"""Core helpers shared across the CrewAI Studio application."""
+
+from .config import load_settings
+from .database import get_db_connection, get_engine
+
+__all__ = [
+    "get_db_connection",
+    "get_engine",
+    "load_settings",
+]

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,60 @@
+"""Configuration utilities centralising environment management."""
+
+from dataclasses import dataclass
+from functools import lru_cache
+import os
+from typing import Optional
+
+DEFAULT_SQLITE_URL = "sqlite:///crewai.db"
+
+
+@dataclass(frozen=True)
+class AgentOpsSettings:
+    """Configuration relevant to the optional AgentOps integration."""
+
+    enabled: bool
+    api_key: Optional[str]
+
+    @property
+    def is_enabled(self) -> bool:
+        """Return ``True`` when AgentOps should be initialised."""
+
+        return self.enabled and bool(self.api_key)
+
+
+@dataclass(frozen=True)
+class DatabaseSettings:
+    """Database connection options."""
+
+    url: str
+    echo: bool = False
+
+
+@dataclass(frozen=True)
+class AppSettings:
+    """Aggregate configuration for the application."""
+
+    database: DatabaseSettings
+    agentops: AgentOpsSettings
+
+
+@lru_cache(maxsize=1)
+def load_settings() -> AppSettings:
+    """Load application settings from the environment."""
+
+    db_url = os.getenv("DB_URL", DEFAULT_SQLITE_URL)
+    db_echo = os.getenv("DATABASE_ECHO", "false").lower() in {"1", "true", "yes"}
+
+    agentops_enabled = os.getenv("AGENTOPS_ENABLED", "false").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+    return AppSettings(
+        database=DatabaseSettings(url=db_url, echo=db_echo),
+        agentops=AgentOpsSettings(
+            enabled=agentops_enabled,
+            api_key=os.getenv("AGENTOPS_API_KEY"),
+        ),
+    )

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -1,0 +1,34 @@
+"""Database helpers built on top of SQLAlchemy."""
+
+from functools import lru_cache
+from typing import Iterator
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Connection, Engine
+
+from .config import load_settings
+
+
+@lru_cache(maxsize=1)
+def get_engine() -> Engine:
+    """Return the shared SQLAlchemy engine instance."""
+
+    settings = load_settings()
+    return create_engine(settings.database.url, echo=settings.database.echo, future=True)
+
+
+def get_db_connection() -> Connection:
+    """Provide a raw SQLAlchemy connection."""
+
+    return get_engine().connect()
+
+
+def iter_rows(result_proxy) -> Iterator[dict]:
+    """Yield result rows as dictionaries, normalising SQLAlchemy versions."""
+
+    if hasattr(result_proxy, "mappings"):
+        yield from result_proxy.mappings()
+    else:  # pragma: no cover - compatibility path for older SQLAlchemy
+        columns = result_proxy.keys()
+        for row in result_proxy:
+            yield dict(zip(columns, row))

--- a/app/db_utils.py
+++ b/app/db_utils.py
@@ -1,59 +1,64 @@
-import sqlite3
-import os
+"""Database persistence helpers for CrewAI Studio entities."""
+
+from __future__ import annotations
+
 import json
-from my_tools import TOOL_CLASSES
-from sqlalchemy import create_engine, text
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple, TYPE_CHECKING
 
-# If you have an environment variable DB_URL for Postgres, use that. 
-# Otherwise, fallback to local SQLite file: 'sqlite:///crewai.db'
-DEFAULT_SQLITE_URL = 'sqlite:///crewai.db'
-DB_URL = os.getenv('DB_URL', DEFAULT_SQLITE_URL)
+from sqlalchemy import text
 
-# Create a SQLAlchemy Engine.
-# For example, DB_URL could be:
-#   "postgresql://username:password@hostname:5432/dbname"
-# or fallback to: "sqlite:///crewai.db"
-engine = create_engine(DB_URL, echo=False)
+from core.database import get_db_connection, iter_rows
 
-def get_db_connection():
-    # conn = sqlite3.connect(DB_NAME)
-    # conn.row_factory = sqlite3.Row
-    # return conn
-    """
-    Return a context-managed connection from the SQLAlchemy engine.
-    """
-    return engine.connect()
+if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+    from my_agent import MyAgent
+    from my_crew import MyCrew
+    from my_knowledge_source import MyKnowledgeSource
+    from my_task import MyTask
+    from my_tools import MyTool
+    from result import Result
 
-def create_tables():
-    create_sql = text('''
+
+@dataclass
+class LoadedEntities:
+    """Aggregate container returned by :func:`load_all_entities`."""
+
+    agents: Sequence["MyAgent"]
+    tasks: Sequence["MyTask"]
+    crews: Sequence["MyCrew"]
+    tools: Sequence["MyTool"]
+    knowledge_sources: Sequence["MyKnowledgeSource"]
+
+
+def initialize_db() -> None:
+    """Initialise the storage by ensuring the ``entities`` table exists."""
+
+    create_sql = text(
+        """
         CREATE TABLE IF NOT EXISTS entities (
             id TEXT PRIMARY KEY,
             entity_type TEXT,
             data TEXT
         )
-    ''')
+        """
+    )
     with get_db_connection() as conn:
         conn.execute(create_sql)
         conn.commit()
 
-def initialize_db():
-    """
-    Initialize the database by creating tables if they do not exist.
-    """
-    create_tables()
 
+def save_entity(entity_type: str, entity_id: str, data: Dict) -> None:
+    """Persist an entity using an upsert semantics."""
 
-def save_entity(entity_type, entity_id, data):
-    # For SQLite ≥ 3.24 and for Postgres, we can do:
-    #   INSERT ... ON CONFLICT(id) DO UPDATE ...
-    # to emulate "INSERT OR REPLACE"
-    upsert_sql = text('''
+    upsert_sql = text(
+        """
         INSERT INTO entities (id, entity_type, data)
         VALUES (:id, :etype, :data)
         ON CONFLICT(id) DO UPDATE
             SET entity_type = EXCLUDED.entity_type,
                 data = EXCLUDED.data
-    ''')
+        """
+    )
     with get_db_connection() as conn:
         conn.execute(
             upsert_sql,
@@ -61,274 +66,326 @@ def save_entity(entity_type, entity_id, data):
                 "id": entity_id,
                 "etype": entity_type,
                 "data": json.dumps(data),
-            }
+            },
         )
         conn.commit()
 
-def load_entities(entity_type):
-    query = text('SELECT id, data FROM entities WHERE entity_type = :etype')
+
+def load_entities(entity_type: str) -> List[Tuple[str, Dict]]:
+    """Return raw entities stored for the given type."""
+
+    query = text("SELECT id, data FROM entities WHERE entity_type = :etype")
     with get_db_connection() as conn:
         result = conn.execute(query, {"etype": entity_type})
-        # result.mappings() gives us rows as dicts (if using SQLAlchemy 1.4+)
-        rows = result.mappings().all()
+        rows = list(iter_rows(result))
     return [(row["id"], json.loads(row["data"])) for row in rows]
 
-def delete_entity(entity_type, entity_id):
-    delete_sql = text('''
+
+def delete_entity(entity_type: str, entity_id: str) -> None:
+    """Remove an entity from the database."""
+
+    delete_sql = text(
+        """
         DELETE FROM entities
         WHERE id = :id AND entity_type = :etype
-    ''')
+        """
+    )
     with get_db_connection() as conn:
         conn.execute(delete_sql, {"id": entity_id, "etype": entity_type})
         conn.commit()
 
-def save_tools_state(enabled_tools):
-    data = {
-        'enabled_tools': enabled_tools
-    }
-    save_entity('tools_state', 'enabled_tools', data)
 
-def load_tools_state():
-    rows = load_entities('tools_state')
+def save_tools_state(enabled_tools: Dict[str, bool]) -> None:
+    data = {"enabled_tools": enabled_tools}
+    save_entity("tools_state", "enabled_tools", data)
+
+
+def load_tools_state() -> Dict[str, bool]:
+    rows = load_entities("tools_state")
     if rows:
-        return rows[0][1].get('enabled_tools', {})
+        return rows[0][1].get("enabled_tools", {})
     return {}
 
-def save_knowledge_source(knowledge_source):
-    data = {
-        'name': knowledge_source.name,
-        'source_type': knowledge_source.source_type,
-        'source_path': knowledge_source.source_path,
-        'content': knowledge_source.content,
-        'metadata': knowledge_source.metadata,
-        'chunk_size': knowledge_source.chunk_size,
-        'chunk_overlap': knowledge_source.chunk_overlap,
-        'created_at': knowledge_source.created_at
-    }
-    save_entity('knowledge_source', knowledge_source.id, data)
 
-def load_knowledge_sources():
+def save_knowledge_source(knowledge_source: "MyKnowledgeSource") -> None:
+    data = {
+        "name": knowledge_source.name,
+        "source_type": knowledge_source.source_type,
+        "source_path": knowledge_source.source_path,
+        "content": knowledge_source.content,
+        "metadata": knowledge_source.metadata,
+        "chunk_size": knowledge_source.chunk_size,
+        "chunk_overlap": knowledge_source.chunk_overlap,
+        "created_at": knowledge_source.created_at,
+    }
+    save_entity("knowledge_source", knowledge_source.id, data)
+
+
+def load_knowledge_sources() -> List["MyKnowledgeSource"]:
     from my_knowledge_source import MyKnowledgeSource
-    rows = load_entities('knowledge_source')
+
+    rows = load_entities("knowledge_source")
     knowledge_sources = []
     for row in rows:
         data = row[1]
         knowledge_source = MyKnowledgeSource(id=row[0], **data)
         knowledge_sources.append(knowledge_source)
-    return sorted(knowledge_sources, key=lambda x: x.created_at)
+    return sorted(knowledge_sources, key=lambda source: source.created_at)
 
-def delete_knowledge_source(knowledge_source_id):
-    delete_entity('knowledge_source', knowledge_source_id)
 
-def save_agent(agent):
+def delete_knowledge_source(knowledge_source_id: str) -> None:
+    delete_entity("knowledge_source", knowledge_source_id)
+
+
+def save_agent(agent: "MyAgent") -> None:
     data = {
-        'created_at': agent.created_at,
-        'role': agent.role,
-        'backstory': agent.backstory,
-        'goal': agent.goal,
-        'allow_delegation': agent.allow_delegation,
-        'verbose': agent.verbose,
-        'cache': agent.cache,
-        'llm_provider_model': agent.llm_provider_model,
-        'temperature': agent.temperature,
-        'max_iter': agent.max_iter,
-        'tool_ids': [tool.tool_id for tool in agent.tools],
-        'knowledge_source_ids': agent.knowledge_source_ids
+        "created_at": agent.created_at,
+        "role": agent.role,
+        "backstory": agent.backstory,
+        "goal": agent.goal,
+        "allow_delegation": agent.allow_delegation,
+        "verbose": agent.verbose,
+        "cache": agent.cache,
+        "llm_provider_model": agent.llm_provider_model,
+        "temperature": agent.temperature,
+        "max_iter": agent.max_iter,
+        "tool_ids": [tool.tool_id for tool in agent.tools],
+        "knowledge_source_ids": agent.knowledge_source_ids,
     }
-    save_entity('agent', agent.id, data)
+    save_entity("agent", agent.id, data)
 
-def load_agents():
+
+def load_agents(tools: Optional[Sequence["MyTool"]] = None) -> List["MyAgent"]:
     from my_agent import MyAgent
-    rows = load_entities('agent')
-    tools_dict = {tool.tool_id: tool for tool in load_tools()}
-    agents = []
+
+    rows = load_entities("agent")
+    tool_map = {tool.tool_id: tool for tool in (tools or load_tools())}
+    agents: List[MyAgent] = []
     for row in rows:
         data = row[1]
-        tool_ids = data.pop('tool_ids', [])
-        knowledge_source_ids = data.pop('knowledge_source_ids', [])
+        tool_ids = data.pop("tool_ids", [])
+        knowledge_source_ids = data.pop("knowledge_source_ids", [])
         agent = MyAgent(id=row[0], knowledge_source_ids=knowledge_source_ids, **data)
-        agent.tools = [tools_dict[tool_id] for tool_id in tool_ids if tool_id in tools_dict]
+        agent.tools = [tool_map[tool_id] for tool_id in tool_ids if tool_id in tool_map]
         agents.append(agent)
-    return sorted(agents, key=lambda x: x.created_at)
+    return sorted(agents, key=lambda agent: agent.created_at)
 
 
-def delete_agent(agent_id):
-    delete_entity('agent', agent_id)
+def delete_agent(agent_id: str) -> None:
+    delete_entity("agent", agent_id)
 
-def save_task(task):
+
+def save_task(task: "MyTask") -> None:
     data = {
-        'description': task.description,
-        'expected_output': task.expected_output,
-        'async_execution': task.async_execution,
-        'agent_id': task.agent.id if task.agent else None,
-        'context_from_async_tasks_ids': task.context_from_async_tasks_ids,
-        'context_from_sync_tasks_ids': task.context_from_sync_tasks_ids,
-        'created_at': task.created_at
+        "description": task.description,
+        "expected_output": task.expected_output,
+        "async_execution": task.async_execution,
+        "agent_id": task.agent.id if task.agent else None,
+        "context_from_async_tasks_ids": task.context_from_async_tasks_ids,
+        "context_from_sync_tasks_ids": task.context_from_sync_tasks_ids,
+        "created_at": task.created_at,
     }
-    save_entity('task', task.id, data)
+    save_entity("task", task.id, data)
 
-def load_tasks():
+
+def load_tasks(agents: Optional[Sequence["MyAgent"]] = None) -> List["MyTask"]:
     from my_task import MyTask
-    rows = load_entities('task')
-    agents_dict = {agent.id: agent for agent in load_agents()}
-    tasks = []
+
+    rows = load_entities("task")
+    agents_dict = {agent.id: agent for agent in (agents or load_agents())}
+    tasks: List[MyTask] = []
     for row in rows:
         data = row[1]
-        agent_id = data.pop('agent_id', None)
+        agent_id = data.pop("agent_id", None)
         task = MyTask(id=row[0], agent=agents_dict.get(agent_id), **data)
         tasks.append(task)
-    return sorted(tasks, key=lambda x: x.created_at)
+    return sorted(tasks, key=lambda task: task.created_at)
 
-def delete_task(task_id):
-    delete_entity('task', task_id)
 
-def save_crew(crew):
+def delete_task(task_id: str) -> None:
+    delete_entity("task", task_id)
+
+
+def save_crew(crew: "MyCrew") -> None:
     data = {
-        'name': crew.name,
-        'process': crew.process,
-        'verbose': crew.verbose,
-        'agent_ids': [agent.id for agent in crew.agents],
-        'task_ids': [task.id for task in crew.tasks],
-        'memory': crew.memory,
-        'cache': crew.cache,
-        'planning': crew.planning,
-        'planning_llm': crew.planning_llm,
-        'max_rpm': crew.max_rpm,
-        'manager_llm': crew.manager_llm,
-        'manager_agent_id': crew.manager_agent.id if crew.manager_agent else None,
-        'created_at': crew.created_at,
-        'knowledge_source_ids': crew.knowledge_source_ids  # Add this line
+        "name": crew.name,
+        "process": crew.process,
+        "verbose": crew.verbose,
+        "agent_ids": [agent.id for agent in crew.agents],
+        "task_ids": [task.id for task in crew.tasks],
+        "memory": crew.memory,
+        "cache": crew.cache,
+        "planning": crew.planning,
+        "planning_llm": crew.planning_llm,
+        "max_rpm": crew.max_rpm,
+        "manager_llm": crew.manager_llm,
+        "manager_agent_id": crew.manager_agent.id if crew.manager_agent else None,
+        "created_at": crew.created_at,
+        "knowledge_source_ids": crew.knowledge_source_ids,
     }
-    save_entity('crew', crew.id, data)
+    save_entity("crew", crew.id, data)
 
-def load_crews():
+
+def load_crews(
+    agents: Optional[Sequence["MyAgent"]] = None,
+    tasks: Optional[Sequence["MyTask"]] = None,
+) -> List["MyCrew"]:
     from my_crew import MyCrew
-    rows = load_entities('crew')
-    agents_dict = {agent.id: agent for agent in load_agents()}
-    tasks_dict = {task.id: task for task in load_tasks()}
-    crews = []
+
+    rows = load_entities("crew")
+    agents_dict = {agent.id: agent for agent in (agents or load_agents())}
+    tasks_dict = {task.id: task for task in (tasks or load_tasks())}
+    crews: List[MyCrew] = []
     for row in rows:
         data = row[1]
         crew = MyCrew(
-            id=row[0], 
-            name=data['name'], 
-            process=data['process'], 
-            verbose=data['verbose'], 
-            created_at=data['created_at'], 
-            memory=data.get('memory'),
-            cache=data.get('cache'),
-            planning=data.get('planning'),
-            planning_llm=data.get('planning_llm'),
-            max_rpm=data.get('max_rpm'), 
-            manager_llm=data.get('manager_llm'),
-            manager_agent=agents_dict.get(data.get('manager_agent_id')),
-            knowledge_source_ids=data.get('knowledge_source_ids', [])  # Add this line
+            id=row[0],
+            name=data["name"],
+            process=data["process"],
+            verbose=data["verbose"],
+            created_at=data["created_at"],
+            memory=data.get("memory"),
+            cache=data.get("cache"),
+            planning=data.get("planning"),
+            planning_llm=data.get("planning_llm"),
+            max_rpm=data.get("max_rpm"),
+            manager_llm=data.get("manager_llm"),
+            manager_agent=agents_dict.get(data.get("manager_agent_id")),
+            knowledge_source_ids=data.get("knowledge_source_ids", []),
         )
-        crew.agents = [agents_dict[agent_id] for agent_id in data['agent_ids'] if agent_id in agents_dict]
-        crew.tasks = [tasks_dict[task_id] for task_id in data['task_ids'] if task_id in tasks_dict]
+        crew.agents = [
+            agents_dict[agent_id] for agent_id in data["agent_ids"] if agent_id in agents_dict
+        ]
+        crew.tasks = [
+            tasks_dict[task_id] for task_id in data["task_ids"] if task_id in tasks_dict
+        ]
         crews.append(crew)
-    return sorted(crews, key=lambda x: x.created_at)
+    return sorted(crews, key=lambda crew: crew.created_at)
 
-def delete_crew(crew_id):
-    delete_entity('crew', crew_id)
 
-def save_tool(tool):
+def delete_crew(crew_id: str) -> None:
+    delete_entity("crew", crew_id)
+
+
+def save_tool(tool: "MyTool") -> None:
     data = {
-        'name': tool.name,
-        'description': tool.description,
-        'parameters': tool.get_parameters()
+        "name": tool.name,
+        "description": tool.description,
+        "parameters": tool.get_parameters(),
     }
-    save_entity('tool', tool.tool_id, data)
+    save_entity("tool", tool.tool_id, data)
 
-def load_tools():
-    rows = load_entities('tool')
-    tools = []
+
+def load_tools() -> List["MyTool"]:
+    from my_tools import TOOL_CLASSES
+
+    rows = load_entities("tool")
+    tools: List[MyTool] = []
     for row in rows:
         data = row[1]
-        tool_class = TOOL_CLASSES[data['name']]
+        tool_class = TOOL_CLASSES[data["name"]]
         tool = tool_class(tool_id=row[0])
-        tool.set_parameters(**data['parameters'])
+        tool.set_parameters(**data["parameters"])
         tools.append(tool)
     return tools
 
-def delete_tool(tool_id):
-    delete_entity('tool', tool_id)
 
-def export_to_json(file_path):
+def delete_tool(tool_id: str) -> None:
+    delete_entity("tool", tool_id)
+
+
+def export_to_json(file_path: str) -> None:
     with get_db_connection() as conn:
-        # Use SQLAlchemy's text() for raw SQL
-        query = text('SELECT * FROM entities')
+        query = text("SELECT * FROM entities")
         result = conn.execute(query)
-        
-        # Convert to list of dictionaries
         rows = [
             {
-                'id': row.id,
-                'entity_type': row.entity_type,
-                'data': json.loads(row.data)
+                "id": row["id"],
+                "entity_type": row["entity_type"],
+                "data": json.loads(row["data"]),
             }
-            for row in result
+            for row in iter_rows(result)
         ]
 
-        # Write to file
-        with open(file_path, 'w') as f:
-            json.dump(rows, f, indent=4)
+    with open(file_path, "w", encoding="utf-8") as file_obj:
+        json.dump(rows, file_obj, indent=4)
 
-def import_from_json(file_path):
-    with open(file_path, 'r') as f:
-        data = json.load(f)
+
+def import_from_json(file_path: str) -> None:
+    with open(file_path, "r", encoding="utf-8") as file_obj:
+        data = json.load(file_obj)
 
     with get_db_connection() as conn:
+        upsert_sql = text(
+            """
+            INSERT INTO entities (id, entity_type, data)
+            VALUES (:id, :etype, :data)
+            ON CONFLICT(id) DO UPDATE
+                SET entity_type = EXCLUDED.entity_type,
+                    data = EXCLUDED.data
+            """
+        )
+
         for entity in data:
-            # Use SQLAlchemy's text() for raw SQL with parameters
-            upsert_sql = text('''
-                INSERT INTO entities (id, entity_type, data)
-                VALUES (:id, :etype, :data)
-                ON CONFLICT(id) DO UPDATE
-                    SET entity_type = EXCLUDED.entity_type,
-                        data = EXCLUDED.data
-            ''')
-            
             conn.execute(
                 upsert_sql,
                 {
-                    "id": entity['id'],
-                    "etype": entity['entity_type'],
-                    "data": json.dumps(entity['data'])
-                }
+                    "id": entity["id"],
+                    "etype": entity["entity_type"],
+                    "data": json.dumps(entity["data"]),
+                },
             )
-            
         conn.commit()
-        
-def save_result(result):
-    """Save a result to the database."""
-    data = {
-        'crew_id': result.crew_id,
-        'crew_name': result.crew_name,
-        'inputs': result.inputs,
-        'result': result.result,
-        'created_at': result.created_at
-    }
-    save_entity('result', result.id, data)
 
-def load_results():
-    """Load all results from the database."""
+
+def save_result(result: "Result") -> None:
+    data = {
+        "crew_id": result.crew_id,
+        "crew_name": result.crew_name,
+        "inputs": result.inputs,
+        "result": result.result,
+        "created_at": result.created_at,
+    }
+    save_entity("result", result.id, data)
+
+
+def load_results() -> List["Result"]:
     from result import Result
-    rows = load_entities('result')
-    results = []
+
+    rows = load_entities("result")
+    results: List[Result] = []
     for row in rows:
         data = row[1]
-        result = Result(
-            id=row[0],
-            crew_id=data['crew_id'],
-            crew_name=data['crew_name'],
-            inputs=data['inputs'],
-            result=data['result'],
-            created_at=data['created_at']
+        results.append(
+            Result(
+                id=row[0],
+                crew_id=data["crew_id"],
+                crew_name=data["crew_name"],
+                inputs=data["inputs"],
+                result=data["result"],
+                created_at=data["created_at"],
+            )
         )
-        results.append(result)
-    return sorted(results, key=lambda x: x.created_at, reverse=True)
+    return sorted(results, key=lambda result: result.created_at, reverse=True)
 
-def delete_result(result_id):
-    """Delete a result from the database."""
-    delete_entity('result', result_id)
+
+def delete_result(result_id: str) -> None:
+    delete_entity("result", result_id)
+
+
+def load_all_entities() -> LoadedEntities:
+    """Load all persisted entities ensuring minimal repeated queries."""
+
+    tools = load_tools()
+    knowledge_sources = load_knowledge_sources()
+    agents = load_agents(tools=tools)
+    tasks = load_tasks(agents=agents)
+    crews = load_crews(agents=agents, tasks=tasks)
+
+    return LoadedEntities(
+        agents=agents,
+        tasks=tasks,
+        crews=crews,
+        tools=tools,
+        knowledge_sources=knowledge_sources,
+    )

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,54 @@
+# CrewAI Studio Architecture Overview
+
+This document summarises the most relevant modules in the Streamlit
+application. Use it together with the in-line docstrings for a quick
+orientation when making changes.
+
+## High-level layout
+
+```
+app/
+├── __init__.py        # Package metadata (application version)
+├── app.py             # Streamlit entry point
+├── core/              # Cross-cutting helpers (configuration, database)
+├── db_utils.py        # Persistence helpers
+├── llms.py            # Model configuration helpers
+├── my_*.py            # Streamlit models (agents, crews, tasks, tools)
+└── pg_*.py            # Streamlit pages
+```
+
+Supporting scripts (Docker, virtual environment helpers, etc.) live in the
+repository root. Static assets such as images are under `img/`.
+
+## Core helpers
+
+- **`app/core/config.py`** – Centralises the loading of environment-based
+  settings and exposes a cached `load_settings()` helper. This ensures all
+  modules observe the same configuration without duplicating logic.
+- **`app/core/database.py`** – Builds the shared SQLAlchemy engine based on
+  the configuration. Provides convenience helpers to obtain a connection or
+  iterate over result rows in a SQLAlchemy-version agnostic way.
+
+## Persistence utilities
+
+- **`app/db_utils.py`** – Offers a light-weight repository layer for agents,
+  tasks, crews, tools, knowledge sources and results. The new
+  `load_all_entities()` helper loads related entities in the correct order so
+  that Streamlit session state can be populated without redundant queries.
+
+## Streamlit entry point
+
+`app/app.py` wires everything together: configuration loading, optional
+AgentOps initialisation, database bootstrap and navigation across Streamlit
+pages. The page objects are instantiated once and cached, removing redundant
+work in each rerun triggered by Streamlit.
+
+## Adding new components
+
+1. Add the new entity implementation (e.g. `my_newthing.py`) and expose it
+   via the relevant page under `pg_*.py`.
+2. Extend `db_utils.py` with persistence helpers, ideally following the
+   existing patterns for serialisation.
+3. Register the page or component in `app/app.py` if it needs to be reachable
+   from the navigation sidebar.
+4. Update this document when structural changes are introduced.


### PR DESCRIPTION
## Summary
- centralize configuration loading and optional AgentOps setup in the Streamlit entry point
- add core helpers for database access and optimise persistence utilities with a bulk loader
- document the application architecture and track the semantic version in the package

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dae641e9448332bb3e8583dfdd12eb